### PR TITLE
Roll back refactoring

### DIFF
--- a/Sources/SwiftScript/Language/Parameter.swift
+++ b/Sources/SwiftScript/Language/Parameter.swift
@@ -9,9 +9,7 @@
 import Foundation
 import Pelota
 
-public struct Parameter : Decodable, Symbol {
-    public var runTime: Runtime? = nil
-    
+public struct Parameter : Decodable {
     let identifier : String
     let term       : Term
     
@@ -24,9 +22,8 @@ public struct Parameter : Decodable, Symbol {
         return identifier
     }
 
-    public var type: ScriptType{
-        return require(runTime, or:"No runtime").resolve(term: term)
+    public func resolve(in runtime:Runtime)->ScriptType {
+        return runtime.resolve(term: term)
     }
-    
 }
 

--- a/Sources/SwiftScript/Runtime/Runtime.swift
+++ b/Sources/SwiftScript/Runtime/Runtime.swift
@@ -45,7 +45,8 @@ public extension Runtime {
     func symbols(for parameters:[Parameter])->[Symbol]{
         var results = [Symbol]()
         for parameter in parameters {
-            results.append(symbol(for: parameter.type, with: parameter.name))
+            
+            results.append(symbol(for: parameter.resolve(in: self), with: parameter.name))
         }
         return results
     }

--- a/Sources/TiledKit/Game Engine Specialisation/SpriteKit/SpriteKit.swift
+++ b/Sources/TiledKit/Game Engine Specialisation/SpriteKit/SpriteKit.swift
@@ -38,8 +38,6 @@ public class SpriteKit : GameEngine {
                 guard texture != 0 else {
                     continue
                 }
-                print(level.engine.textureCache.count," keys")
-                print(level.engine.textureCache.allGids)
                 let spriteNode = SKSpriteNode(texture: (allTextures[texture]))
                 spriteNode.position = CGPoint(x:(x*level.tileWidth+layer.offset.x) - pixelWidth >> 1, y:(-y*level.tileHeight-layer.offset.y) + pixelHeight >> 1)
                 spriteNode.position.x += spriteNode.size.width / 2


### PR DESCRIPTION
Swift compiler performance dropped to zero with a pattern that used a single protocol to pull together a single concrete implementation. 